### PR TITLE
SL-5540 - Automatically remove corner rounding for iPhone 8 type devices (in full screen)

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -244,7 +244,7 @@ open class PanModalPresentationController: UIPresentationController {
             else { return }
 
             self.adjustPresentedViewFrame()
-            if presentable.shouldRoundTopCorners {
+            if presentable.shouldRoundTopCorners.shouldRound(topOffset: presentable.topOffset) {
                 self.addRoundedCorners(to: self.presentedView)
             }
         })
@@ -369,7 +369,7 @@ private extension PanModalPresentationController {
             addDragIndicatorView(to: presentedView)
         }
 
-        if presentable.shouldRoundTopCorners {
+        if presentable.shouldRoundTopCorners.shouldRound(topOffset: presentable.topOffset) {
             addRoundedCorners(to: presentedView)
         }
 

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -30,6 +30,10 @@ public enum AnimationMode {
 public enum ShouldRoundTopCorners {
     case never
     case always
+
+    /// Will round the corners:
+    /// Always if modal is not full screen;
+    /// Only for iPhone X-type devices if modal is full screen
     case automatic
 
     func shouldRound(topOffset: CGFloat) -> Bool {

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -36,7 +36,7 @@ public enum ShouldRoundTopCorners {
     /// Only for iPhone X-type devices if modal is full screen
     case automatic
 
-    func shouldRound(topOffset: CGFloat) -> Bool {
+    public func shouldRound(topOffset: CGFloat) -> Bool {
         switch self {
         case .never:
             return false

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -27,6 +27,30 @@ public enum AnimationMode {
     case cubicBezier(controlPoint1: CGPoint, controlPoint2: CGPoint)
 }
 
+public enum ShouldRoundTopCorners {
+    case never
+    case always
+    case automatic
+
+    func shouldRound(topOffset: CGFloat) -> Bool {
+        switch self {
+        case .never:
+            return false
+        case .always:
+            return true
+        case .automatic:
+            if topOffset > 0 {
+                // not full screen
+                return true
+            } else {
+                // full screen
+                // round only if device has notch
+                return UIDevice.current.hasNotch
+            }
+        }
+    }
+}
+
 public protocol PanModalPresentable: AnyObject {
 
     /**
@@ -199,9 +223,9 @@ public protocol PanModalPresentable: AnyObject {
     /**
      A flag to determine if the top corners should be rounded.
 
-     Default value is true.
+     Default value is `.automatic`.
      */
-    var shouldRoundTopCorners: Bool { get }
+    var shouldRoundTopCorners: ShouldRoundTopCorners { get }
 
     /**
      A flag to determine if a drag indicator should be shown
@@ -285,4 +309,16 @@ public protocol PanModalPresentable: AnyObject {
      */
     func panModalStopDragging()
 }
+
+extension UIDevice {
+    // https://stackoverflow.com/a/63705090
+    var hasNotch: Bool {
+        if #available(iOS 11.0, *) {
+            let keyWindow = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first
+            return (keyWindow?.safeAreaInsets.bottom ?? 0) > 0
+        }
+        return false
+    }
+}
+
 #endif

--- a/Sample/View Controllers/Alert/AlertViewController.swift
+++ b/Sample/View Controllers/Alert/AlertViewController.swift
@@ -50,8 +50,8 @@ class AlertViewController: UIViewController, PanModalPresentable {
         return UIColor.black.withAlphaComponent(0.1)
     }
 
-    var shouldRoundTopCorners: Bool {
-        return false
+    var shouldRoundTopCorners: ShouldRoundTopCorners {
+        return .never
     }
 
     var showDragIndicator: Bool {

--- a/Sample/View Controllers/Basic/UIViewController+PanModalPresentable.swift
+++ b/Sample/View Controllers/Basic/UIViewController+PanModalPresentable.swift
@@ -109,7 +109,7 @@ extension PanModalPresentable where Self: UIViewController {
     }
 
     var showDragIndicator: Bool {
-        shouldRoundTopCorners
+        shouldRoundTopCorners.shouldRound(topOffset: topOffset)
     }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {

--- a/Sample/View Controllers/Basic/UIViewController+PanModalPresentable.swift
+++ b/Sample/View Controllers/Basic/UIViewController+PanModalPresentable.swift
@@ -104,8 +104,8 @@ extension PanModalPresentable where Self: UIViewController {
         false
     }
 
-    var shouldRoundTopCorners: Bool {
-        isPanModalPresented
+    var shouldRoundTopCorners: ShouldRoundTopCorners {
+        isPanModalPresented ? .automatic : .never
     }
 
     var showDragIndicator: Bool {

--- a/Sample/View Controllers/Full Screen/FullScreenNavController.swift
+++ b/Sample/View Controllers/Full Screen/FullScreenNavController.swift
@@ -42,8 +42,8 @@ extension FullScreenNavController: PanModalPresentable {
         [.allowUserInteraction, .beginFromCurrentState]
     }
 
-    var shouldRoundTopCorners: Bool {
-        false
+    var shouldRoundTopCorners: ShouldRoundTopCorners {
+        .never
     }
 
     var showDragIndicator: Bool {

--- a/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
+++ b/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
@@ -106,8 +106,8 @@ class StackedProfileViewController: UIViewController, PanModalPresentable {
         return false
     }
 
-    var shouldRoundTopCorners: Bool {
-        return true
+    var shouldRoundTopCorners: ShouldRoundTopCorners {
+        return .automatic
     }
 
 }


### PR DESCRIPTION
Required for [SL-5540](https://surprisehr.atlassian.net/browse/SL-5540)

Instead of `shouldRoundTopCorners: Bool`, there's now

```swift
public enum ShouldRoundTopCorners {
    case never
    case always
    case automatic
}
```

For `.automatic`, will automatically decide if corners need to be rounded:
- Always if modal is **not** full screen
- Only for iPhone X type devices if modal is full screen

Thanks @trori46, @kmadiar & @OstapHolub for help!